### PR TITLE
feat(config): add base-branch config and ensure worker branches are based off main

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -2,7 +2,7 @@
 # GitHub issue tracker (required).
 # Set GITHUB_TOKEN in the environment; workflow resolves $GITHUB_TOKEN at runtime.
 # Token: for orchestrator-only, Issues: Read-only (or classic public_repo/repo). For PR-driven workflow the agent needs write: Issues, Pull requests, Contents. See docs/SPEC/10-github-tracker.md.
-# Addendum 1 (docs/SPEC_ADDENDUM_1.md): include_labels / exclude_labels filter candidates; claim_label is auto-excluded so the agent can "claim" an issue; pr_open_label optional for PR-driven flow.
+# Addendum 1 (docs/SPEC_ADDENDUM_1.md): include_labels / exclude_labels filter candidates; claim_label is auto-excluded so the agent can "claim" an issue; pr_base_branch (default main) for worker branches and PR target; pr_open_label optional for PR-driven flow.
 # Addendum 2 (docs/SPEC_ADDENDUM_2.md): fix_pr re-dispatches the agent when the PR has failing checks or when someone mentions the configured handle (e.g. @symphony).
 fix_pr: true
 tracker:
@@ -51,14 +51,14 @@ agent:
 # Prompt template (how the agent receives the ticket)
 
 The text below is the prompt sent to the agent for each issue. Edit it to change how the ticket is presented.
-Liquid variables: `issue` (title, identifier, state, description, url, labels), optional `attempt` (retry number).
+Liquid variables: `issue` (title, identifier, state, description, url, labels), optional `attempt` (retry number), optional `workflow` (when set: `workflow.pr_base_branch` — base branch for worker branches and PR target, e.g. main or develop).
 See https://shopify.github.io/liquid/ for syntax.
 
 **Tracker and completion:** The runner only **reads** the tracker (no write access). When the agent is done, it should **close the issue** (or move it to a terminal state) using its own tools (e.g. GitHub CLI, API, or a comment for a human to close). Once the issue is closed, the runner will stop re-dispatching it on the next poll.
 
 **Claim label (Addendum 1):** Add the claim label `symphony-claimed` to this issue as your first step (e.g. `gh issue edit … --add-label symphony-claimed`). That prevents other workers from picking the same issue and survives restarts.
 
-**PR-driven handoff (Addendum 1):** You MUST (1) push your branch, (2) open a PR with body containing "Fixes #N", (3) post a comment on this issue with the PR URL. Do not consider the task complete until all three are done. Use `gh pr create` and `gh issue comment <number> --body "PR: <url>"` if available. Do **not** merge the PR—a human merges; closing the issue happens when the PR is merged. Optionally add the label `pr-open` to the issue when the PR is open.
+**PR-driven handoff (Addendum 1):** Worker branches MUST be based off the configured base branch (e.g. fetch and checkout `main` or the branch in `workflow.pr_base_branch`, then create `symphony/issue-<number>` from it). When opening a PR, target that same base (e.g. `gh pr create --base {{ workflow.pr_base_branch | default: "main" }} --body "Fixes #N"`). You MUST (1) push your branch, (2) open a PR with body containing "Fixes #N", (3) post a comment on this issue with the PR URL. Do not consider the task complete until all three are done. Use `gh pr create` and `gh issue comment <number> --body "PR: <url>"` if available. Do **not** merge the PR—a human merges; closing the issue happens when the PR is merged. Optionally add the label `pr-open` to the issue when the PR is open.
 
 ---
 
@@ -94,11 +94,11 @@ This is **attempt {{ attempt }}**. A previous run may have been interrupted or f
 
 1. **Claim the issue** (if the workflow uses a claim label): Add the claim label to this issue first (e.g. `gh issue edit … --add-label symphony-claimed`) so no other worker picks it up.
 2. Read the issue and the codebase in this workspace.
-3. Implement or fix what the issue asks for. Use a single branch per issue (e.g. `symphony/issue-<number>`) if opening a PR.
+3. Implement or fix what the issue asks for. Use a single branch per issue (e.g. `symphony/issue-<number>`), created from the base branch (e.g. `main` or `{{ workflow.pr_base_branch | default: "main" }}`), if opening a PR.
 4. Run tests and fix any failures (`devenv shell -- moon run :test` as appropriate).
 5. Follow project conventions (see `.cursor/rules`, `docs/`, and existing code).
 6. When done, either:
-   - **PR-driven:** You MUST complete all of: (1) push your branch, (2) open a PR with body "Fixes #N" (e.g. `gh pr create --body "Fixes #N"`), (3) post a comment on this issue with the PR link (e.g. `gh issue comment <issue-number> --body "PR: https://github.com/…"`). Do not exit until all three are done. Do not merge the PR—a human merges. Optionally add the `pr_open_label` to the issue when the PR is open. **Or**
+   - **PR-driven:** You MUST complete all of: (1) push your branch, (2) open a PR with body "Fixes #N" targeting the base branch (e.g. `gh pr create --base main --body "Fixes #N"` or use `--base {{ workflow.pr_base_branch | default: "main" }}` when the variable is set), (3) post a comment on this issue with the PR link (e.g. `gh issue comment <issue-number> --body "PR: https://github.com/…"`). Do not exit until all three are done. Do not merge the PR—a human merges. Optionally add the `pr_open_label` to the issue when the PR is open. **Or**
    - **Direct close:** Summarize in a comment, then **close this issue** (e.g. `gh issue close` or GitHub UI) so the runner stops picking it up. If you cannot close issues, add a clear "ready to close" comment for a maintainer.
 
 ## Before you're done (required for PR-driven flow)

--- a/crates/symphony-config/src/build.rs
+++ b/crates/symphony-config/src/build.rs
@@ -26,6 +26,7 @@ struct RawTracker {
   pr_open_label: Option<String>,
   fix_pr_head_branch_pattern: Option<String>,
   mention_handle: Option<String>,
+  pr_base_branch: Option<String>,
 }
 
 /// Raw runner map from workflow front matter.
@@ -120,6 +121,7 @@ pub fn from_workflow_config(value: &serde_json::Value) -> Result<ServiceConfig, 
     pr_open_label: tracker.pr_open_label,
     fix_pr_head_branch_pattern: tracker.fix_pr_head_branch_pattern,
     mention_handle: tracker.mention_handle,
+    pr_base_branch: tracker.pr_base_branch,
   };
 
   let runner_raw = raw
@@ -501,6 +503,29 @@ mod tests {
     assert_eq!(config.tracker.mention_handle.as_deref(), Some("symphony"));
   }
 
+  #[test]
+  fn from_workflow_config_tracker_pr_base_branch_omitted() {
+    let value = serde_json::json!({
+        "tracker": { "repo": "r", "api_key": "k" },
+        "runner": { "command": "c" }
+    });
+    let config = from_workflow_config(&value).unwrap();
+    assert!(config.tracker.pr_base_branch.is_none());
+    assert_eq!(config.tracker.effective_pr_base_branch(), "main");
+  }
+
+  #[test]
+  fn from_workflow_config_tracker_pr_base_branch_parsed() {
+    let value = serde_json::json!({
+        "tracker": { "repo": "r", "api_key": "k", "pr_base_branch": "develop" },
+        "runner": { "command": "c" }
+    });
+    let config = from_workflow_config(&value).unwrap();
+    assert_eq!(config.tracker.pr_base_branch.as_deref(), Some("develop"));
+    assert_eq!(config.tracker.effective_pr_base_branch(), "develop");
+  }
+
+  #[test]
   fn from_workflow_config_workspace_main_repo_path_omitted() {
     let value = serde_json::json!({
         "tracker": { "repo": "r", "api_key": "k" },

--- a/crates/symphony-config/src/config.rs
+++ b/crates/symphony-config/src/config.rs
@@ -39,6 +39,8 @@ pub struct TrackerConfig {
   pub fix_pr_head_branch_pattern: Option<String>,
   /// SPEC_ADDENDUM_2 B.5: handle to look for in comments (e.g. "symphony" → @symphony). If set, qualifying mention triggers dispatch.
   pub mention_handle: Option<String>,
+  /// Base branch for worker branches and PR target (e.g. main, develop). When unset, default is "main".
+  pub pr_base_branch: Option<String>,
 }
 
 impl TrackerConfig {
@@ -75,6 +77,11 @@ impl TrackerConfig {
       .terminal_states
       .as_deref()
       .unwrap_or_else(|| DEFAULT_TERMINAL_STATES.as_slice())
+  }
+
+  /// Base branch for worker branches and PR target; defaults to "main" when not configured.
+  pub fn effective_pr_base_branch(&self) -> &str {
+    self.pr_base_branch.as_deref().unwrap_or("main")
   }
 }
 
@@ -226,6 +233,7 @@ mod tests {
         pr_open_label: None,
         fix_pr_head_branch_pattern: None,
         mention_handle: None,
+        pr_base_branch: None,
       },
       runner: RunnerConfig {
         command: "codex app-server".into(),
@@ -315,6 +323,7 @@ mod tests {
       pr_open_label: None,
       fix_pr_head_branch_pattern: None,
       mention_handle: None,
+      pr_base_branch: None,
     };
     assert!(t.effective_exclude_labels().is_none());
   }
@@ -333,6 +342,7 @@ mod tests {
       pr_open_label: None,
       fix_pr_head_branch_pattern: None,
       mention_handle: None,
+      pr_base_branch: None,
     };
     assert_eq!(
       t.effective_exclude_labels(),
@@ -354,6 +364,7 @@ mod tests {
       pr_open_label: None,
       fix_pr_head_branch_pattern: None,
       mention_handle: None,
+      pr_base_branch: None,
     };
     let eff = t.effective_exclude_labels().unwrap();
     assert_eq!(eff.len(), 2);
@@ -375,6 +386,7 @@ mod tests {
       pr_open_label: None,
       fix_pr_head_branch_pattern: None,
       mention_handle: None,
+      pr_base_branch: None,
     };
     assert_eq!(t.effective_exclude_labels(), Some(vec!["claimed".into()]));
   }
@@ -393,6 +405,7 @@ mod tests {
       pr_open_label: None,
       fix_pr_head_branch_pattern: None,
       mention_handle: None,
+      pr_base_branch: None,
     };
     let eff = t.effective_exclude_labels().unwrap();
     assert_eq!(eff.len(), 2);
@@ -413,6 +426,7 @@ mod tests {
       pr_open_label: None,
       fix_pr_head_branch_pattern: None,
       mention_handle: None,
+      pr_base_branch: None,
     };
     assert_eq!(t.active_states_slice(), &["open".to_string()]);
   }
@@ -431,6 +445,7 @@ mod tests {
       pr_open_label: None,
       fix_pr_head_branch_pattern: None,
       mention_handle: None,
+      pr_base_branch: None,
     };
     assert_eq!(
       t.active_states_slice(),
@@ -452,6 +467,7 @@ mod tests {
       pr_open_label: None,
       fix_pr_head_branch_pattern: None,
       mention_handle: None,
+      pr_base_branch: None,
     };
     assert_eq!(t.terminal_states_slice(), &["closed".to_string()]);
   }
@@ -470,10 +486,49 @@ mod tests {
       pr_open_label: None,
       fix_pr_head_branch_pattern: None,
       mention_handle: None,
+      pr_base_branch: None,
     };
     assert_eq!(
       t.terminal_states_slice(),
       &["closed".to_string(), "done".to_string()]
     );
+  }
+
+  #[test]
+  fn effective_pr_base_branch_default() {
+    let t = TrackerConfig {
+      repo: "r".into(),
+      api_key: "k".into(),
+      endpoint: None,
+      active_states: None,
+      terminal_states: None,
+      include_labels: None,
+      exclude_labels: None,
+      claim_label: None,
+      pr_open_label: None,
+      fix_pr_head_branch_pattern: None,
+      mention_handle: None,
+      pr_base_branch: None,
+    };
+    assert_eq!(t.effective_pr_base_branch(), "main");
+  }
+
+  #[test]
+  fn effective_pr_base_branch_explicit() {
+    let t = TrackerConfig {
+      repo: "r".into(),
+      api_key: "k".into(),
+      endpoint: None,
+      active_states: None,
+      terminal_states: None,
+      include_labels: None,
+      exclude_labels: None,
+      claim_label: None,
+      pr_open_label: None,
+      fix_pr_head_branch_pattern: None,
+      mention_handle: None,
+      pr_base_branch: Some("develop".into()),
+    };
+    assert_eq!(t.effective_pr_base_branch(), "develop");
   }
 }

--- a/crates/symphony-config/src/error.rs
+++ b/crates/symphony-config/src/error.rs
@@ -52,6 +52,7 @@ mod tests {
       pr_open_label: None,
       fix_pr_head_branch_pattern: None,
       mention_handle: None,
+      pr_base_branch: None,
     };
     let errs = t.validate().unwrap_err();
     let e = ConfigValidationError::Tracker(errs);

--- a/crates/symphony-prompt/src/lib.rs
+++ b/crates/symphony-prompt/src/lib.rs
@@ -8,4 +8,4 @@ mod error;
 mod render;
 
 pub use error::PromptError;
-pub use render::render_prompt;
+pub use render::{WorkflowPromptContext, render_prompt};

--- a/crates/symphony-prompt/src/render.rs
+++ b/crates/symphony-prompt/src/render.rs
@@ -7,11 +7,19 @@ use symphony_domain::Issue;
 
 use crate::PromptError;
 
-/// Render prompt from template with issue and optional attempt.
+/// Workflow context exposed to the prompt template (e.g. base branch for PRs).
+#[derive(Debug, Clone)]
+pub struct WorkflowPromptContext {
+  /// Base branch for worker branches and PR target (e.g. main, develop).
+  pub pr_base_branch: String,
+}
+
+/// Render prompt from template with issue, optional attempt, and optional workflow context.
 pub fn render_prompt(
   template: &str,
   issue: &Issue,
   attempt: Option<u32>,
+  workflow: Option<&WorkflowPromptContext>,
 ) -> Result<String, PromptError> {
   if template.trim().is_empty() {
     return Ok("You are working on an issue from GitHub.".to_string());
@@ -31,6 +39,12 @@ pub fn render_prompt(
       .map(|a| Value::scalar(a as i64))
       .unwrap_or(Value::Nil),
   );
+  if let Some(w) = workflow {
+    globals.insert(
+      "workflow".into(),
+      Value::Object(workflow_to_liquid_object(w)),
+    );
+  }
   let root = Value::Object(globals);
   let view = root
     .as_object()
@@ -39,6 +53,15 @@ pub fn render_prompt(
     .render(view)
     .map_err(|e| PromptError::TemplateRender(e.to_string()))?;
   Ok(out)
+}
+
+fn workflow_to_liquid_object(w: &WorkflowPromptContext) -> Object {
+  let mut obj = Object::new();
+  obj.insert(
+    "pr_base_branch".into(),
+    Value::scalar(w.pr_base_branch.clone()),
+  );
+  obj
 }
 
 fn issue_to_liquid_object(issue: &Issue) -> Object {
@@ -85,19 +108,49 @@ mod tests {
 
   #[test]
   fn render_prompt_empty_template() {
-    let out = render_prompt("   ", &sample_issue(), None).unwrap();
+    let out = render_prompt("   ", &sample_issue(), None, None).unwrap();
     assert!(out.contains("GitHub"));
   }
 
   #[test]
   fn render_prompt_simple() {
-    let out = render_prompt("Title: {{ issue.title }}", &sample_issue(), None).unwrap();
+    let out = render_prompt("Title: {{ issue.title }}", &sample_issue(), None, None).unwrap();
     assert_eq!(out, "Title: Fix the bug");
   }
 
   #[test]
   fn render_prompt_with_attempt() {
-    let out = render_prompt("Attempt: {{ attempt }}", &sample_issue(), Some(2)).unwrap();
+    let out = render_prompt("Attempt: {{ attempt }}", &sample_issue(), Some(2), None).unwrap();
     assert_eq!(out, "Attempt: 2");
+  }
+
+  #[test]
+  fn render_prompt_with_workflow_pr_base_branch() {
+    let workflow = WorkflowPromptContext {
+      pr_base_branch: "main".to_string(),
+    };
+    let out = render_prompt(
+      "Base: {{ workflow.pr_base_branch }}",
+      &sample_issue(),
+      None,
+      Some(&workflow),
+    )
+    .unwrap();
+    assert_eq!(out, "Base: main");
+  }
+
+  #[test]
+  fn render_prompt_workflow_develop() {
+    let workflow = WorkflowPromptContext {
+      pr_base_branch: "develop".to_string(),
+    };
+    let out = render_prompt(
+      "Branch: {{ workflow.pr_base_branch }}",
+      &sample_issue(),
+      None,
+      Some(&workflow),
+    )
+    .unwrap();
+    assert_eq!(out, "Branch: develop");
   }
 }

--- a/crates/symphony-runner/src/loop_.rs
+++ b/crates/symphony-runner/src/loop_.rs
@@ -19,7 +19,7 @@ use symphony_orchestration::{
   AgentUpdatePayload, OrchestratorMessage, WorkerExitReason, apply_agent_update, apply_worker_exit,
   available_slots, can_dispatch, release_claim, remove_retry_on_dispatch,
 };
-use symphony_prompt::render_prompt;
+use symphony_prompt::{WorkflowPromptContext, render_prompt};
 use symphony_tracker::{
   fetch_candidate_issues, fetch_check_runs_for_ref, fetch_commit_status_for_ref,
   fetch_has_qualifying_mention, fetch_issue_states_by_ids, fetch_issues_with_label,
@@ -649,7 +649,15 @@ async fn run_worker_to_completion(
     }
   }
 
-  let prompt = match render_prompt(&prompt_template, &issue, Some(retry_attempt)) {
+  let workflow_ctx = WorkflowPromptContext {
+    pr_base_branch: config.tracker.effective_pr_base_branch().to_string(),
+  };
+  let prompt = match render_prompt(
+    &prompt_template,
+    &issue,
+    Some(retry_attempt),
+    Some(&workflow_ctx),
+  ) {
     Ok(p) => p,
     Err(e) => {
       warn!(%issue_id, %e, "render prompt failed");
@@ -800,6 +808,7 @@ mod tests {
         pr_open_label: None,
         fix_pr_head_branch_pattern: None,
         mention_handle: None,
+        pr_base_branch: None,
       },
       runner: symphony_config::RunnerConfig {
         command: "echo".into(),

--- a/crates/symphony-runner/src/reload.rs
+++ b/crates/symphony-runner/src/reload.rs
@@ -81,6 +81,7 @@ mod tests {
         pr_open_label: None,
         fix_pr_head_branch_pattern: None,
         mention_handle: None,
+        pr_base_branch: None,
       },
       runner: symphony_config::RunnerConfig {
         command: "echo".into(),

--- a/crates/symphony-runner/src/startup.rs
+++ b/crates/symphony-runner/src/startup.rs
@@ -58,6 +58,7 @@ mod tests {
         pr_open_label: None,
         fix_pr_head_branch_pattern: None,
         mention_handle: None,
+        pr_base_branch: None,
       },
       runner: symphony_config::RunnerConfig {
         command: "echo".into(),

--- a/docs/SPEC_ADDENDUM_1.md
+++ b/docs/SPEC_ADDENDUM_1.md
@@ -65,13 +65,20 @@ A **claim** is the guarantee that at most one worker is assigned to an issue at 
 
 The workflow MAY define a PR-driven handoff: the worker implements the task on a branch, opens a pull request, comments on the issue, then exits. The worker does not merge the PR; a human merges, and the issue is closed (e.g. via “Fixes #N” in the PR).
 
+### A.3.0 Base branch (worker branches and PR target)
+
+- **Config key:** `tracker.pr_base_branch` (optional; string).
+- **Semantics:** The branch from which worker branches MUST be created and to which pull requests MUST target. When unset, the default is `main`. Repositories that use a different default (e.g. `develop`) MAY set this key.
+- **Worker behaviour:** The worker MUST create its per-issue branch from this base (e.g. fetch and checkout the base branch, then create `symphony/issue-<number>` from it). Workspace setup (e.g. `after_create` hook) and/or prompt instructions MUST make this explicit.
+- **PR target:** When opening a PR, the worker MUST target this same branch (e.g. `gh pr create --base <pr_base_branch>` or equivalent).
+
 ### A.3.1 Branch and work
 
-- The worker works in the per-issue workspace (e.g. a git worktree). It MUST use a single branch per issue (e.g. `symphony/issue-<number>` or a configurable naming convention). All changes are committed on that branch.
+- The worker works in the per-issue workspace (e.g. a git worktree). It MUST use a single branch per issue (e.g. `symphony/issue-<number>` or a configurable naming convention), created from the configured base branch (A.3.0). All changes are committed on that branch.
 
 ### A.3.2 Pull request
 
-- When implementation is ready, the worker MUST open a pull request from that branch to the default branch. The PR body SHOULD reference the issue (e.g. “Fixes #N”) so that merging the PR will close the issue (tracker behaviour).
+- When implementation is ready, the worker MUST open a pull request from that branch to the configured base branch (A.3.0; default `main`). The PR body SHOULD reference the issue (e.g. “Fixes #N”) so that merging the PR will close the issue (tracker behaviour).
 - The worker MUST NOT merge the PR. Merging is performed by a human.
 
 ### A.3.3 Comment on issue
@@ -109,6 +116,7 @@ The workflow MAY define a PR-driven handoff: the worker implements the task on a
 | `tracker.include_labels` | A.1.1 | optional list of strings | Candidate must have at least one of these labels. |
 | `tracker.exclude_labels` | A.1.2 | optional list of strings | Candidate must have none of these labels. |
 | `tracker.claim_label` | A.2.1 | optional string | Label the agent adds when claiming; should be in exclude_labels. |
+| `tracker.pr_base_branch` | A.3.0 | optional string | Base branch for worker branches and PR target; default `main`. |
 | `tracker.pr_open_label` | A.3.6 | optional string | Optional label when PR is open; should be in exclude_labels if used. |
 
-All keys are optional. When absent, behaviour matches the base SPEC (no label-based filtering, no claim label semantics).
+All keys are optional. When absent, behaviour matches the base SPEC (no label-based filtering, no claim label semantics). The prompt template MAY expose the effective base branch (e.g. as a Liquid variable `workflow.pr_base_branch`) so the agent can use it for checkout and `gh pr create --base`.


### PR DESCRIPTION
Fixes #22

- **tracker.pr_base_branch** (optional): defaults to `main`; worker branches and PRs target this branch
- **TrackerConfig.effective_pr_base_branch()**; parsed from workflow front matter
- **symphony-prompt**: `WorkflowPromptContext` with `pr_base_branch`; expose `workflow.pr_base_branch` in Liquid
- Runner passes workflow context to `render_prompt`
- **SPEC_ADDENDUM_1**: A.3.0 base branch, config table row, prompt variable note
- **WORKFLOW.md**: document Liquid variable; instruct checkout base, `gh pr create --base`